### PR TITLE
Fix missing Material3 style

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation 'com.google.android.material:material:1.11.0'
 
     debugImplementation 'androidx.compose.ui:ui-tooling'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.suppressUnsupportedCompileSdk=34


### PR DESCRIPTION
## Summary
- add Material Components library dependency to satisfy Theme.Material3 resources
- suppress compile SDK warning

## Testing
- `gradle assembleDebug` *(fails: Could not resolve artifacts due to network)*