### PR TITLE
Fix Kotlin version mismatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10'
     }
 }
 


### PR DESCRIPTION
## Summary
- downgrade Kotlin Gradle plugin to 1.8.10 to match Compose compiler

## Testing
- `./gradlew tasks` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*