### PR TITLE
Fix bottom bar navigation stack

### DIFF
--- a/app/src/main/java/com/example/composeapp/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/composeapp/navigation/AppNavigation.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -62,7 +63,11 @@ fun AppNavigation() {
                 BottomBar(currentScreen) { screen ->
                     if (screen.route != currentRoute) {
                         navController.navigate(screen.route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
                             launchSingleTop = true
+                            restoreState = true
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- prevent bottom bar screens from endlessly stacking up

## Testing
- `gradle build` *(fails: Could not resolve dependencies)*